### PR TITLE
Replace scoped css to class scoping

### DIFF
--- a/src/components/vue-tel-input-vuetify.vue
+++ b/src/components/vue-tel-input-vuetify.vue
@@ -681,22 +681,22 @@ export default {
 </script>
 
 <style src="../assets/sprite.css"></style>
-<style lang="scss" scoped>
+<style lang="scss">
 .vue-tel-input-vuetify {
   display: flex;
   align-items: center;
-}
 
-.country-code {
-  width: 75px;
-}
+  .country-code {
+    width: 75px;
+  }
 
-li.last-preferred {
-  border-bottom: 1px solid #cacaca;
-}
+  li.last-preferred {
+    border-bottom: 1px solid #cacaca;
+  }
 
-.vti__flag {
-  margin-right: 5px;
-  margin-left: 5px;
+  .vti__flag {
+    margin-right: 5px;
+    margin-left: 5px;
+  }
 }
 </style>


### PR DESCRIPTION
Vue scoped css is evil, class scoping is always the preferred method :+1: