### PR TITLE
Fix vuetify-loader issue #2

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "module": "dist/vue-tel-input-vuetify.esm.js",
   "unpkg": "dist/vue-tel-input-vuetify.min.js",
   "files": [
-    "dist/"
+    "dist/",
+    "src/"
   ],
   "dependencies": {
     "awesome-phonenumber": "^2.15.0",


### PR DESCRIPTION
This will add the /src directory when publishing the npm package, allowing to import the vue component directly and avoid the vuetify-loader issue