### PR TITLE
Replace js scoped css to class scoped css

### DIFF
--- a/src/lib/vue-tel-input-vuetify.vue
+++ b/src/lib/vue-tel-input-vuetify.vue
@@ -694,22 +694,22 @@ export default {
 </script>
 
 <style src="./sprite.css"></style>
-<style lang="scss" scoped>
+<style lang="scss">
 .vue-tel-input-vuetify {
   display: flex;
   align-items: center;
-}
 
-.country-code {
-  width: 75px;
-}
+  .country-code {
+    width: 75px;
+  }
 
-li.last-preferred {
-  border-bottom: 1px solid #cacaca;
-}
+  li.last-preferred {
+    border-bottom: 1px solid #cacaca;
+  }
 
-.vti__flag {
-  margin-right: 5px;
-  margin-left: 5px;
+  .vti__flag {
+    margin-right: 5px;
+    margin-left: 5px;
+  }
 }
 </style>


### PR DESCRIPTION
Make the css of this lib non scoped, as it's usually bad practice to use scoped css when you already have a unique class for your plugin and there is no nesting of components
Because the css is included in js rather than css so it's added multiple times on the fly everytime a component is displayed, which doesn't have good performance and also makes the css unoptimizable by postcss