### PR TITLE
Updated css class .vue-tel-input-vuetify

### DIFF
--- a/lib/vue-tel-input-vuetify.vue
+++ b/lib/vue-tel-input-vuetify.vue
@@ -762,8 +762,9 @@ export default {
 
 .vue-tel-input-vuetify {
   display: flex;
-  align-items: center;
-
+  justify-content: center;
+  align-items: flex-start;
+  
   .country-code {
     width: 75px;
   }


### PR DESCRIPTION
I am using it since a long time ago. But whenever I use it I've to override the class .vue-tel-input-vuetify in my main because it got deform whenever validation rules applied on it. So I need developer to accept my change.