### PR TITLE
Fix js error: Cannot read properties of undefined (reading 'toLowerCase')

### DIFF
--- a/lib/vue-tel-input-vuetify.vue
+++ b/lib/vue-tel-input-vuetify.vue
@@ -534,11 +534,15 @@ export default {
          * 1. If the phone included prefix (+12), try to get the country and set it
          */
         if (this.phone && this.phone[0] === '+') {
-          const activeCountry = PhoneNumber(this.phone).getRegionCode();
+          let activeCountry = PhoneNumber(this.phone).getRegionCode();
+          this.findCountry(activeCountry);
           if (activeCountry) {
-            this.choose(activeCountry);
-            resolve();
-            return;
+            activeCountry = this.findCountry(activeCountry);
+            if (activeCountry) {
+              this.choose(activeCountry);
+              resolve();
+              return;
+            }
           }
         }
         /**


### PR DESCRIPTION
`this.choose` must be called with an object containing the isoCode but here it's called with only the iso code which triggers various errors and non desired behaviors 

Superseedes #109 

Fixes #108 